### PR TITLE
Fix query_workbooks_in_project when using project luid

### DIFF
--- a/tableau_rest_api/tableau_rest_api_connection.py
+++ b/tableau_rest_api/tableau_rest_api_connection.py
@@ -875,7 +875,7 @@ class TableauRestApiConnection(TableauBase):
     def query_workbooks_in_project_for_username(self, project_name_or_luid, username):
         self.start_log_block()
         if self.is_luid(project_name_or_luid):
-            project_luid = self.query_project_by_luid(project_name_or_luid)
+            project_luid = project_name_or_luid
         else:
             project_luid = self.query_project_luid_by_name(project_name_or_luid)
         workbooks = self.query_workbooks_by_username(username)


### PR DESCRIPTION
Hi,

This fixes the issue #5. There was a problem as the code was querying a project and assigning it to a variable as it was project_luid. An alternative solution is to properly assign the id of the newly retrieved project to the variable, something as:

`project_luid = self.query_project_by_luid(project_name_or_luid).get('id')`

But I prefer solution as one request to the server is saved.

