### PR TITLE
fix of "TypeError: argument of type 'NoneType' is not iterable"

### DIFF
--- a/tableau_documents/tableau_file.py
+++ b/tableau_documents/tableau_file.py
@@ -196,7 +196,7 @@ class TableauFile(TableauBase):
                         continue
 
                     # If file is listed in the data_file_replacement_map, write data from the mapped in file
-                    if filename in data_file_replacement_map:
+                    if data_file_replacement_map and filename in data_file_replacement_map:
                         #data_file_obj = open(filename, mode='wb')
                         #data_file_obj.write(data_file_replacement_map[filename])
                         #data_file_obj.close()


### PR DESCRIPTION
The new version throws an error if data_file_replacement_map is not given.
This should fix the problem.

```
Traceback (most recent call last):
  File "/code/tableau/tasks.py", line 286, in ***
    f'{workbook.name} {project.name}')
  File "/usr/local/lib/python3.7/site-packages/tableau_tools/tableau_documents/tableau_file.py", line 199, in save_new_file
    if filename in data_file_replacement_map:
TypeError: argument of type 'NoneType' is not iterable
``