### PR TITLE
Remove print statement when saving WB

### DIFF
--- a/tableau_documents/tableau_workbook.py
+++ b/tableau_documents/tableau_workbook.py
@@ -84,7 +84,6 @@ class TableauWorkbook(LoggingMethods, TableauDocument):
                     for ds in final_datasources:
                         self.log('Writing datasource XML into the workbook')
                         ds_string = ds.get_xml_string()
-                        print(ds_string)
                         if isinstance(ds_string, bytes):
                             final_string = ds_string.decode('utf-8')
                         else:


### PR DESCRIPTION
Just remove a print statement that was printing the whole xml string to std output