### PR TITLE
rest_api_base.py: fix a bug with views_to_hide_list

### DIFF
--- a/tableau_rest_api/methods/rest_api_base.py
+++ b/tableau_rest_api/methods/rest_api_base.py
@@ -832,6 +832,7 @@ class TableauRestApiBase(LookupMethods, LoggingMethods, TableauRestXml):
                             v = ET.Element('view')
                             v.set('name', view_name)
                             v.set('hidden', 'true')
+                            vs.append(v)
                         t1.append(vs)
 
                 # Description only allowed for Flows as of 3.3


### PR DESCRIPTION
Is views_to_hide_list empty or not, all views were published anyway. Some xml tags were lost.