### PR TITLE
Update rest_api_base.py

### DIFF
--- a/tableau_rest_api/methods/rest_api_base.py
+++ b/tableau_rest_api/methods/rest_api_base.py
@@ -1362,6 +1362,22 @@ class TableauRestApiBase36(TableauRestApiBase35):
         self._request_obj: Optional[RestXmlRequest] = None
         self._request_json_obj: Optional[RestJsonRequest] = None
 
+        self.site_roles = (
+            u'Interactor',
+            u'Publisher',
+            u'SiteAdministrator',
+            u'Unlicensed',
+            u'UnlicensedWithPublish',  # This was sunset at some point
+            u'Viewer',
+            u'ViewerWithPublish',
+            u'ServerAdministrator',
+            u'ReadOnly',
+            u'Explorer',
+            u'ExplorerCanPublish',
+            u'SiteAdministratorExplorer',
+            u'Creator',
+            u'SiteAdministratorCreator'
+        )
         # Lookup caches to minimize calls
         self.username_luid_cache = {}
         self.group_name_luid_cache = {}


### PR DESCRIPTION
TableauRestApiBase36 does not initialise TableauRestAPIBase (commented out) I'm not 100% sure why, assume it has something to do with the implementation of personal access tokens. 
add_user_by_username() in user.py validates the specified site_role against the tuple of allowed site_roles as defined in TableauRestAPIBase which doesn't get initialised for versions after 3.6. Adding this tuple to TableauRestApiBase36 
Would be good to understand better why the chain of inheritance is broken in 3.6?